### PR TITLE
Fix for IE8

### DIFF
--- a/lib/jquery.text-overflow.js
+++ b/lib/jquery.text-overflow.js
@@ -13,6 +13,8 @@
 		rtrim = function (str) {
 			return str.replace(/\s+$/g, '');
 		},
+		
+		propertyName = document.createTextNode('').textContent ? 'textContent' : 'data',
 
 		domSplit = function (root, maxIndex, options) {
 			var index = 0, result = [],
@@ -39,7 +41,7 @@
 								if (options.wholeWord) {
 									clipIndex = Math.min(maxIndex - index, tmp.textContent.substring(0, maxIndex - index).lastIndexOf(' '));
 								}
-								tmp.textContent = options.trim ? rtrim(tmp.textContent.substring(0, clipIndex)) : tmp.textContent.substring(0, clipIndex);
+								tmp[propertyName] = options.trim ? rtrim(tmp[propertyName].substring(0, clipIndex)) : tmp[propertyName].substring(0, clipIndex);
 								result[result.length - 1].appendChild(tmp);	
 							}
 							index += nodes[i].length;


### PR DESCRIPTION
IE8 doesn't have .textContent (nor even .innerText) for text nodes, so we should determine correct property name before using it.
